### PR TITLE
Create account view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8304,6 +8304,15 @@
         "shallowequal": "1.0.2"
       }
     },
+    "react-side-effect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.3.tgz",
+      "integrity": "sha1-USwlq+DewXKDTEAB7FxR4E1BvFw=",
+      "requires": {
+        "exenv": "1.2.2",
+        "shallowequal": "1.0.2"
+      }
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8295,6 +8295,15 @@
         "shallowequal": "1.0.2"
       }
     },
+    "react-side-effect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.3.tgz",
+      "integrity": "sha1-USwlq+DewXKDTEAB7FxR4E1BvFw=",
+      "requires": {
+        "exenv": "1.2.2",
+        "shallowequal": "1.0.2"
+      }
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-modal": "^2.2.4",
     "react-router": "^4.1.2",
     "react-router-dom": "^4.1.2",
+    "react-router-modal": "^1.1.13",
     "sass-loader": "^6.0.6",
     "style-loader": "0.18.2",
     "sw-precache-webpack-plugin": "0.11.4",

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Progress = () => (
+  <div />
+);
+
+export default Progress;

--- a/src/components/forms/create-account/Email.js
+++ b/src/components/forms/create-account/Email.js
@@ -21,6 +21,15 @@ const Email = () => (
         </div>
       </div>
     </fieldset>
+    <div className="modal-cta">
+      <div className="row col-12 no-gutters p-0">
+        <div className="col-sm-auto col-12 pl-0 pr-sm-2 pr-0 mb-sm-0 mb-3">
+          <button className="btn btn-primary btn-lg btn-block" type="submit">
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
   </form>
 );
 

--- a/src/components/forms/create-account/Email.js
+++ b/src/components/forms/create-account/Email.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Progress from '../../Progress';
+
+const Email = () => (
+  <form>
+    <Progress />
+
+    <h2>Next your email</h2>
+    <p>Enter your email below.</p>
+
+    <fieldset className="form-group">
+      <label htmlFor="username">Email</label>
+      <div clasName="input-container">
+        <div className="icon" />
+        <div className="input-prefix">
+          <input
+            aria-describedby="username"
+            className="form-control form-control-lg prefix"
+            id="username"
+            name="username"
+            required
+            type="email"
+          />
+        </div>
+      </div>
+    </fieldset>
+  </form>
+);
+
+export default Email;
+

--- a/src/components/forms/create-account/Email.js
+++ b/src/components/forms/create-account/Email.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import Progress from '../../Progress';
 
 const Email = () => (
   <form>
-    <Progress />
-
     <h2>Next your email</h2>
     <p>Enter your email below.</p>
 

--- a/src/components/forms/create-account/Password.js
+++ b/src/components/forms/create-account/Password.js
@@ -20,6 +20,15 @@ const Password = () => (
         </div>
       </div>
     </fieldset>
+    <div className="modal-cta">
+      <div className="row col-12 no-gutters p-0">
+        <div className="col-sm-auto col-12 pl-0 pr-sm-2 pr-0 mb-sm-0 mb-3">
+          <button className="btn btn-primary btn-lg btn-block" type="submit">
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
   </form>
 );
 

--- a/src/components/forms/create-account/Password.js
+++ b/src/components/forms/create-account/Password.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const Password = () => (
+  <form>
+    <h2>Choose a password</h2>
+
+    <fieldset className="form-group">
+      <label htmlFor="username">Password</label>
+      <div clasName="input-container">
+        <div className="icon" />
+        <div className="input-prefix">
+          <input
+            aria-describedby="password"
+            className="form-control form-control-lg prefix"
+            id="password"
+            name="password"
+            required
+            type="password"
+          />
+        </div>
+      </div>
+    </fieldset>
+  </form>
+);
+
+export default Password;
+

--- a/src/components/forms/create-account/Phone.js
+++ b/src/components/forms/create-account/Phone.js
@@ -21,6 +21,15 @@ const Phone = () => (
         </div>
       </div>
     </fieldset>
+    <div className="modal-cta">
+      <div className="row col-12 no-gutters p-0">
+        <div className="col-sm-auto col-12 pl-0 pr-sm-2 pr-0 mb-sm-0 mb-3">
+          <button className="btn btn-primary btn-lg btn-block" type="submit">
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
   </form>
 );
 

--- a/src/components/forms/create-account/Phone.js
+++ b/src/components/forms/create-account/Phone.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Progress from '../../Progress';
+
+const Phone = () => (
+  <form>
+    <Progress />
+
+    <h2>Next your phone</h2>
+    <p>Enter your phone below.</p>
+
+    <fieldset className="form-group">
+      <label htmlFor="username">Phone number</label>
+      <div clasName="input-container">
+        <div className="icon" />
+        <div className="input-prefix">
+          <input
+            aria-describedby="phone"
+            className="form-control form-control-lg prefix"
+            id="phone"
+            name="phone"
+            required
+            type="phone"
+          />
+        </div>
+      </div>
+    </fieldset>
+  </form>
+);
+
+export default Phone;

--- a/src/components/forms/create-account/Phone.js
+++ b/src/components/forms/create-account/Phone.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import Progress from '../../Progress';
 
 const Phone = () => (
   <form>
-    <Progress />
-
     <h2>Next your phone</h2>
     <p>Enter your phone below.</p>
 

--- a/src/components/forms/create-account/Username.js
+++ b/src/components/forms/create-account/Username.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import Progress from '../../Progress';
 
 const Username = () => (
   <form>
-    <Progress />
-
     <h2>Select an Account Name</h2>
     <p>Your account name is how you will be known on EOS.</p>
 

--- a/src/components/forms/create-account/Username.js
+++ b/src/components/forms/create-account/Username.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Progress from '../../Progress';
+
+const Username = () => (
+  <form>
+    <Progress />
+
+    <h2>Select an Account Name</h2>
+    <p>Your account name is how you will be known on EOS.</p>
+
+    <fieldset className="form-group">
+      <label htmlFor="username">Account Name</label>
+      <div clasName="input-container">
+        <div className="icon" />
+        <div className="input-prefix">
+          <input
+            aria-describedby="username"
+            className="form-control form-control-lg prefix"
+            id="username"
+            name="username"
+            required
+            type="text"
+          />
+        </div>
+      </div>
+    </fieldset>
+  </form>
+);
+
+export default Username;
+

--- a/src/components/forms/create-account/Username.js
+++ b/src/components/forms/create-account/Username.js
@@ -21,6 +21,15 @@ const Username = () => (
         </div>
       </div>
     </fieldset>
+    <div className="modal-cta">
+      <div className="row col-12 no-gutters p-0">
+        <div className="col-sm-auto col-12 pl-0 pr-sm-2 pr-0 mb-sm-0 mb-3">
+          <button className="btn btn-primary btn-lg btn-block" type="submit">
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
   </form>
 );
 

--- a/src/components/forms/create-account/index.js
+++ b/src/components/forms/create-account/index.js
@@ -1,3 +1,4 @@
 export { default as EmailForm } from './Email';
+export { default as PasswordForm } from './Password';
 export { default as PhoneForm } from './Phone';
 export { default as UsernameForm } from './Username';

--- a/src/components/forms/create-account/index.js
+++ b/src/components/forms/create-account/index.js
@@ -1,0 +1,3 @@
+export { default as EmailForm } from './Email';
+export { default as PhoneForm } from './Phone';
+export { default as UsernameForm } from './Username';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,4 @@
-export { EmailForm, PhoneForm, UsernameForm } from './forms/create-account';
+export { EmailForm, PasswordForm, PhoneForm, UsernameForm } from './forms/create-account';
 export { default as Balance } from './Balance';
 export { default as Footer } from './Footer';
 export { default as Header } from './Header';
@@ -6,7 +6,7 @@ export { default as Icon } from './Icon';
 export { default as List } from './List';
 export { default as LoginForm } from './forms/Login';
 export { default as Navbar } from './Navbar';
+export { default as PreferencesForm } from './forms/Preferences';
 export { default as Progress } from './Progress';
 export { default as ResetPasswordForm } from './forms/ResetPassword';
 export { default as TransferForm } from './forms/Transfer';
-export { default as PreferencesForm } from './forms/Preferences';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+export { EmailForm, PhoneForm, UsernameForm } from './forms/create-account';
 export { default as Balance } from './Balance';
 export { default as Footer } from './Footer';
 export { default as Header } from './Header';
@@ -5,6 +6,7 @@ export { default as Icon } from './Icon';
 export { default as List } from './List';
 export { default as LoginForm } from './forms/Login';
 export { default as Navbar } from './Navbar';
+export { default as Progress } from './Progress';
 export { default as ResetPasswordForm } from './forms/ResetPassword';
 export { default as TransferForm } from './forms/Transfer';
 export { default as PreferencesForm } from './forms/Preferences';

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Route, Switch } from 'react-router';
+import { Route, Redirect, Switch } from 'react-router';
 import { Helmet } from 'react-helmet';
 import {
   Header,
@@ -46,7 +46,7 @@ class App extends Component {
     super(props, context);
 
     this.previousLocation = {
-      pathname: '/',
+      pathname: '/about',
       hash: '',
       search: '',
     };
@@ -74,8 +74,8 @@ class App extends Component {
         <Header />
         <div className="flex-fill">
           <Navbar />
-          <Switch location={isModal ? this.previousLocation : location}>
-            <Scene>
+          <Scene>
+            <Switch location={isModal ? this.previousLocation : location}>
               <Route
                 component={Transfer}
                 exact
@@ -112,11 +112,11 @@ class App extends Component {
               <Route
                 component={NoMatch}
               />
-
-              <Footer />
-            </Scene>
-          </Switch>
+            </Switch>
+            <Footer />
+          </Scene>
         </div>
+
         {isModal ?
           <Modal
             isOpen

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Route, Redirect, Switch } from 'react-router';
+import { Route, Switch } from 'react-router';
 import { Helmet } from 'react-helmet';
 import {
   Header,

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -7,7 +7,7 @@ import {
   Navbar } from '../components';
 import {
   About,
-  Faqs,
+  Faq,
   NoMatch,
   Permissions,
   Preferences,
@@ -98,8 +98,8 @@ class App extends Component {
                 path="/about"
               />
               <Route
-                component={Faqs}
-                path="/faqs"
+                component={Faq}
+                path="/faq"
               />
               <Route
                 component={Users}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Route } from 'react-router';
 import { Helmet } from 'react-helmet';
+import { Route, Switch } from 'react-router';
 import {
   Header,
   Footer,
@@ -17,10 +17,13 @@ import {
   Users } from '../routes';
 import Modal from 'react-modal';
 import Login from './Login';
+import CreateAccount from './CreateAccount';
 
 const Scene = ({
   children,
   className = 'main-content',
+  location,
+  computedMatch,
   ...props }) => (
   <div
     className={className}
@@ -33,10 +36,38 @@ const Scene = ({
 class App extends Component {
   static defaultProps = {
     className: 'app container-fluid p-0 row no-gutters d-flex',
+    modalRoutes: [
+      '/create-account',
+      '/login',
+    ],
+  }
+
+  constructor(props, context) {
+    super(props, context);
+
+    this.previousLocation = {
+      pathname: '/',
+      hash: '',
+      search: '',
+    };
+  }
+
+  componentWillUpdate(nextProps) {
+    const { location } = this.props;
+    // set previousLocation if props.location is not modal
+    if (
+      nextProps.history.action !== 'POP' &&
+      (!location.state || !location.state.modal)
+    ) {
+      this.previousLocation = this.props.location;
+    }
   }
 
   render() {
-    const { className, isOpen } = this.props;
+    const { className, location, modalRoutes } = this.props;
+    const isModal = modalRoutes.some(r => new RegExp(r).test(location.pathname));
+
+    console.log(this.previousLocation, location);
 
     return (
       <main className={className}>
@@ -45,48 +76,63 @@ class App extends Component {
         <Header />
         <div className="flex-fill">
           <Navbar />
-          <Scene>
+          <Switch location={isModal ? this.previousLocation : location}>
+            <Scene>
+              <Route
+                component={Transfer}
+                exact
+                path="/(|transfer)/"
+              />
+              <Route
+                component={TransactionHistory}
+                path="/transactions"
+              />
+              <Route
+                component={Permissions}
+                path="/permissions"
+              />
+              <Route
+                component={Profile}
+                path="/user/:id"
+              />
+              <Route
+                component={About}
+                path="/about"
+              />
+              <Route
+                component={Faqs}
+                path="/faqs"
+              />
+              <Route
+                component={Users}
+                path="/users"
+              />
+              <Route
+                component={Preferences}
+                path="/preferences"
+              />
+              <Route
+                component={NoMatch}
+              />
+
+              <Footer />
+            </Scene>
+          </Switch>
+        </div>
+        {isModal ?
+          <Modal
+            isOpen
+            contentLabel={location.pathname}
+          >
             <Route
-              component={Transfer}
-              exact
-              path="/"
+              component={Login}
+              path="/login"
             />
             <Route
-              component={Transfer}
-              path="/transfer"
+              component={CreateAccount}
+              path="/create-account"
             />
-            <Route
-              component={TransactionHistory}
-              path="/transactions"
-            />
-            <Route
-              component={Permissions}
-              path="/permissions"
-            />
-            <Route
-              component={Profile}
-              path="/user/:id"
-            />
-            <Route
-              component={About}
-              path="/about"
-            />
-            <Route
-              component={Faqs}
-              path="/faqs"
-            />
-            <Route
-              component={Users}
-              path="/users"
-            />
-            <Route
-              component={Preferences}
-              path="/preferences"
-            />
-            <Route
-              component={NoMatch}
-              path="*"
-            />
+<<<<<<< HEAD
             <Footer />
           </Scene>
         </div>
@@ -95,6 +141,9 @@ class App extends Component {
         >
           <Login />
         </Modal>
+=======
+          </Modal> : null}
+>>>>>>> Update <App /> routes, Add Progress, CreateAccount and forms
       </main>
     );
   }

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -54,6 +54,7 @@ class App extends Component {
 
   componentWillUpdate(nextProps) {
     const { location } = this.props;
+
     // set previousLocation if props.location is not modal
     if (
       nextProps.history.action !== 'POP' &&
@@ -66,6 +67,8 @@ class App extends Component {
   render() {
     const { className, location, modalRoutes } = this.props;
     const isModal = modalRoutes.some(r => new RegExp(r).test(location.pathname));
+
+    location.state = { modal: isModal };
 
     return (
       <main className={className}>

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -33,13 +33,14 @@ const Scene = ({
   </div>
 );
 
+const modalRoutes = Object.freeze([
+  '/create-account',
+  '/login',
+]);
+
 class App extends Component {
   static defaultProps = {
     className: 'app container-fluid p-0 row no-gutters d-flex',
-    modalRoutes: [
-      '/create-account',
-      '/login',
-    ],
   }
 
   constructor(props, context) {
@@ -65,7 +66,7 @@ class App extends Component {
   }
 
   render() {
-    const { className, location, modalRoutes } = this.props;
+    const { className, location } = this.props;
     const isModal = modalRoutes.some(r => new RegExp(r).test(location.pathname));
 
     location.state = { modal: isModal };

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Helmet } from 'react-helmet';
 import { Route, Switch } from 'react-router';
 import { Helmet } from 'react-helmet';
 import {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import { Route, Switch } from 'react-router';
+import { Helmet } from 'react-helmet';
 import {
   Header,
   Footer,
@@ -67,8 +68,6 @@ class App extends Component {
     const { className, location, modalRoutes } = this.props;
     const isModal = modalRoutes.some(r => new RegExp(r).test(location.pathname));
 
-    console.log(this.previousLocation, location);
-
     return (
       <main className={className}>
         <Helmet titleTemplate="%s | EOS Wallet" defaultTitle="EOS Wallet" />
@@ -132,18 +131,7 @@ class App extends Component {
               component={CreateAccount}
               path="/create-account"
             />
-<<<<<<< HEAD
-            <Footer />
-          </Scene>
-        </div>
-        <Modal
-          isOpen={isOpen}
-        >
-          <Login />
-        </Modal>
-=======
           </Modal> : null}
->>>>>>> Update <App /> routes, Add Progress, CreateAccount and forms
       </main>
     );
   }

--- a/src/containers/CreateAccount.js
+++ b/src/containers/CreateAccount.js
@@ -14,6 +14,14 @@ const CreateAccount = ({ children }) => (
       <button className="js-modal-close">x</button>
     </div>
     <div className="modal-body">
+      <div className="login-progress">
+        <ul className="d-flex justify-content-between items-center col-12 mb-4">
+          <li className="col-0 active" />
+          <li className="col-4 active" />
+          <li className="col-4" />
+          <li className="col-4" />
+        </ul>
+      </div>
       <Progress />
       <Route exact path="/create-account" component={UsernameForm} />
       <Route path="/create-account/email" component={EmailForm} />

--- a/src/containers/CreateAccount.js
+++ b/src/containers/CreateAccount.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Route } from 'react-router';
-import { EmailForm, PhoneForm, UsernameForm, Progress } from '../components';
+import {
+  EmailForm,
+  PhoneForm,
+  UsernameForm,
+  PasswordForm,
+  Progress } from '../components';
 
 const CreateAccount = ({ children }) => (
   <div className="login">
@@ -13,6 +18,7 @@ const CreateAccount = ({ children }) => (
       <Route exact path="/create-account" component={UsernameForm} />
       <Route path="/create-account/email" component={EmailForm} />
       <Route path="/create-account/phone" component={PhoneForm} />
+      <Route path="/create-account/password" component={PasswordForm} />
     </div>
   </div>
 );

--- a/src/containers/CreateAccount.js
+++ b/src/containers/CreateAccount.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Route } from 'react-router';
+import { EmailForm, PhoneForm, UsernameForm, Progress } from '../components';
+
+const CreateAccount = ({ children }) => (
+  <div className="login">
+    <div className="login-header modal-header">
+      <h2>Create your EOS account</h2>
+      <button className="js-modal-close">x</button>
+    </div>
+    <div className="modal-body">
+      <Progress />
+      <Route exact path="/create-account" component={UsernameForm} />
+      <Route path="/create-account/email" component={EmailForm} />
+      <Route path="/create-account/phone" component={PhoneForm} />
+    </div>
+  </div>
+);
+
+export default CreateAccount;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from './containers';
-import { Router } from 'react-router';
+import { Router, Route } from 'react-router';
 import createHistory from 'history/createBrowserHistory';
 
 // TODO assess if needed
@@ -13,7 +13,7 @@ const history = createHistory();
 
 ReactDOM.render(
   <Router history={history}>
-    <App />
+    <Route component={App} />
   </Router>,
   document.getElementById('root'),
 );

--- a/src/routes/Faq.js
+++ b/src/routes/Faq.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 
-class Faqs extends Component {
+class Faq extends Component {
   render() {
     return (
       <div>
@@ -14,4 +14,4 @@ class Faqs extends Component {
   }
 }
 
-export default Faqs;
+export default Faq;

--- a/src/routes/Preferences.js
+++ b/src/routes/Preferences.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { PreferencesForm } from '../components';
 import { Helmet } from 'react-helmet';
 
-
 class Preferences extends Component {
   render() {
     return (

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,5 @@
 export { default as About } from './About';
-export { default as Faqs } from './Faqs';
+export { default as Faq } from './Faq';
 export { default as NoMatch } from './NoMatch';
 export { default as Permissions } from './Permissions';
 export { default as Preferences } from './Preferences';

--- a/src/styles/includes.scss
+++ b/src/styles/includes.scss
@@ -5,6 +5,7 @@
 @import 'app';
 @import 'flex';
 @import 'fonts';
+@import 'modals';
 @import 'components/header';
 @import 'components/footer';
 @import 'components/navbar';

--- a/src/styles/modals.scss
+++ b/src/styles/modals.scss
@@ -37,4 +37,90 @@
       visibility: visible;
     }
   }
+  /*
+  .login-progress {
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+      position: relative;
+      z-index: 0;
+      li {
+        background-color: $bg-grey-60;
+        width: 25px;
+        height: 25px;
+        @include border-radius(15px);
+        position: relative;
+        &:first-of-type {
+          &:after {
+            display: none;
+          }
+        }
+        &:after {
+          content: "";
+          position: absolute;
+          top: 11px;
+          right: 0px;
+          width: 150px;
+          height: 3px;
+          background-color: $bg-grey-60;
+          z-index: -1;
+        }
+        &.active {
+          width: 30px;
+          height: 30px;
+          background-color: $green;
+          &:after {
+            background-color: $green;
+            top: 14px;
+          }
+        }
+      }
+    }
+  }
+  */
+  .login-progress {
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+      position: relative;
+      z-index: 0;
+      width: 100%;
+      padding: 0 15px;
+      li {
+        position: relative;
+        height: 30px;
+        &:after {
+          content: "";
+          position: absolute;
+          right: -15px;
+          top: 3px;
+          background-color: $bg-grey-60;
+          width: 24px;
+          height: 24px;
+          @include border-radius(15px);
+        }
+        &:before {
+          content: "";
+          position: absolute;
+          top: 14px;
+          left: 0px;
+          width: 100%;
+          height: 3px;
+          background-color: $bg-grey-60;
+          z-index: -1;
+        }
+        &.active {
+          &:after {
+            width: 30px;
+            height: 30px;
+            top: 0;
+            background-color: $green;
+          }
+          &:before {
+            background-color: $green;
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Add the `/create-account` view, also updates the modals in the app to have their own routes, the previous route will remain in background. If there was no previous route, `/about` defaults to be the background route (JIC user isn't logged in, shows an unauth'd view).

### Now accessible via URL:

* `/create-account` (default starts with username)
* `/create-account/phone`
* `/create-account/email`
* `/create-account/password`
* `/login`

<img width="933" alt="screen shot 2017-08-22 at 10 22 26" src="https://user-images.githubusercontent.com/1743355/29573154-e0dbb540-8723-11e7-9987-ab2bc2190ed1.png">
<img width="986" alt="screen shot 2017-08-22 at 10 22 31" src="https://user-images.githubusercontent.com/1743355/29573155-e0e69af0-8723-11e7-868f-a5205d2f45f5.png">
<img width="954" alt="screen shot 2017-08-22 at 10 22 37" src="https://user-images.githubusercontent.com/1743355/29573156-e0e6e14a-8723-11e7-9154-d1a65089562f.png">
<img width="989" alt="screen shot 2017-08-22 at 10 22 43" src="https://user-images.githubusercontent.com/1743355/29573157-e0e7ce98-8723-11e7-9345-2dfa6c613630.png">